### PR TITLE
Fix Python 2/3 check.

### DIFF
--- a/bitstring.py
+++ b/bitstring.py
@@ -443,11 +443,10 @@ BYTE_REVERSAL_DICT = dict()
 
 # For Python 2.x/ 3.x coexistence
 # Yes this is very very hacky.
-try:
-    xrange
+if sys.version_info[0] == 2:
     for i in range(256):
         BYTE_REVERSAL_DICT[i] = chr(int("{0:08b}".format(i)[::-1], 2))
-except NameError:
+else:
     for i in range(256):
         BYTE_REVERSAL_DICT[i] = bytes([int("{0:08b}".format(i)[::-1], 2)])
     from io import IOBase as file


### PR DESCRIPTION
There are some third party packages which patch out xrange and leak
their patch into global scope.

While they shouldn't be doing this, bitstring should also check based on
the version number rather than the behaviour so that these sorts of
patches won't stop it working.